### PR TITLE
Update interrupts.lua to fix error with Skada-WotLK and update cooldowns.lua to display tooltips correctly

### DIFF
--- a/modules/cooldowns.lua
+++ b/modules/cooldowns.lua
@@ -1050,7 +1050,7 @@ local function UpdateCooldownGroup(
 			cooldownFrame[i]:SetScript("OnEnter", function(self)
 				if self.spellid then
 					GameTooltip:SetOwner(self, "ANCHOR_RIGHT")
-					GameTooltip:SetSpellByID(self.spellid)
+					GameTooltip:SetHyperlink(GetSpellLink(self.spellid))
 				end
 			end)
 			cooldownFrame[i]:SetScript("OnLeave", function(self) GameTooltip:Hide() end)

--- a/modules/interrupts.lua
+++ b/modules/interrupts.lua
@@ -14,7 +14,7 @@ local defaults = {
 
 local Interrupt = GladiusEx:NewGladiusExModule("InterruptsEx", defaults, defaults)
     
-INTERRUPTS = {   
+local INTERRUPTS = {   
     [6552]  = { duration = 4 }, -- [Warrior] Pummel
     [48827] = { duration = 3 }, -- [Paladin] Avenger's Shield
     [1766] = { duration = 5 }, -- [Rogue] Kick


### PR DESCRIPTION
Fixes unwanted interaction with Skada-WotLK revisited

fixes error on Character Log in

Message: Interface\AddOns\Skada\Modules\Interrupts.lua:240: bad argument to 'format' (string expected, got table)
Time: 07/27/24 01:36:05
Count: 1
Stack: [C]: ?
Interface\AddOns\Skada\Modules\Interrupts.lua:240: in function <Interface\AddOns\Skada\Modules\Interrupts.lua:234>
(tail call): ?
[C]: ?
[string "safecall Dispatcher[1]"]:9: in function <[string "safecall Dispatcher[1]"]:5>
(tail call): ?
...s\ElvUI\Libraries\Ace3\AceAddon-3.0\AceAddon-3.0.lua:529: in function `InitializeAddon'
...s\ElvUI\Libraries\Ace3\AceAddon-3.0\AceAddon-3.0.lua:644: in function <...s\ElvUI\Libraries\Ace3\AceAddon-3.0\AceAddon-3.0.lua:636>
Locals: No locals to dump

After this addition of local, Skada and GladiusEx work together. It doesn't impact GladiusEX because this table INTERRUPTS is only used in interrupts.lua once and is no problem if its local and not global (locals load faster pre cata too)