### PR TITLE
Update GladiusEx to hide Enemy/Friendly match leavers

### DIFF
--- a/GladiusEx.lua
+++ b/GladiusEx.lua
@@ -1016,7 +1016,6 @@ function GladiusEx:UpdateUnitState(unit, stealth, dead)
         self.buttons[unit].unit_state = STATE_DEAD
         self.buttons[unit]:SetScript("OnUpdate", nil)
         self.buttons[unit]:SetAlpha(self.db[unit].deadAlpha)
-        self.buttons[unit]:Hide()
     elseif stealth then
         self.buttons[unit].unit_state = STATE_STEALTH
         self.buttons[unit]:SetScript("OnUpdate", nil)

--- a/GladiusEx.lua
+++ b/GladiusEx.lua
@@ -748,7 +748,7 @@ function GladiusEx:CHAT_MSG_SYSTEM(event, msg)
     if InCombatLockdown() then
         local name = string.gsub(msg, " has left the battle", "")
         for frame in pairs(self.buttons) do
-            if frame and string.find(UnitName(frame), name) and not UnitExists(frame) then
+            if frame and UnitName(frame) and string.find(UnitName(frame), name) and not UnitExists(frame) then
                 self:UpdateUnitState(frame, false, true)
             end
         end


### PR DESCRIPTION
fixes https://github.com/ManneN1/GladiusEx-WotLK/issues/27

When opponent leaves ARENA_OPPONENT_UPDATE(unit, type=destroyed) is fired. If we see this event we set the UnitUpdateState to STATE_DEAD 

When party member leaves CHAT_MSG_SYSTEM = "X has left the battle" fires. If we see this we set the PartyFrame for the unit to STATE_DEAD